### PR TITLE
[Fix] Crash on React Native Reload

### DIFF
--- a/android/cpp-adapter.cpp
+++ b/android/cpp-adapter.cpp
@@ -14,7 +14,9 @@ struct QuickSQLiteBridge : jni::JavaClass<QuickSQLiteBridge> {
     javaClassStatic()->registerNatives(
         {// initialization for JSI
          makeNativeMethod("installNativeJsi",
-                          QuickSQLiteBridge::installNativeJsi)});
+                          QuickSQLiteBridge::installNativeJsi),
+         {"clearStateNativeJsi", "()V", (void*)&QuickSQLiteBridge::clearStateNativeJsi}     
+    });
   }
 
 private:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.0",
   "description": "Fast SQLite for react-native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -80,6 +80,5 @@
         }
       ]
     ]
-  },
-  "dependencies": {}
+  }
 }

--- a/scripts/dev-package-version.js
+++ b/scripts/dev-package-version.js
@@ -1,17 +1,16 @@
 /**
- * Dev package version like 0.0.0-dev-hash seem to cause issues with the podspec
+ * Dev package version like 0.0.0-dev-[hash] seem to cause issues with the podspec
  * This script will remove the -dev-hash from the version.
  */
 const fs = require('fs');
 const path = require('path');
-const version = process.argv[2];
+const version = require('../package.json').version;
 
-if (version.includes('0.0.0')) {
+if (version.includes('-')) {
   console.log(`Storing current version for dev version ${version}`);
-  const currentPackage = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'));
-  // Backup the current version
+
   fs.writeFileSync(
     path.join(__dirname, '../meta.json'),
-    JSON.stringify({ version: currentPackage.version }, null, '\t')
+    JSON.stringify({ version: version.split('-')[0] }, null, '\t')
   );
 }

--- a/scripts/dev-package-version.js
+++ b/scripts/dev-package-version.js
@@ -1,16 +1,18 @@
 /**
  * Dev package version like 0.0.0-dev-[hash] seem to cause issues with the podspec
  * This script will remove the -dev-hash from the version.
+ * Side Note: Versions above 0.0.0 e.g. 0.0.1-dev-[hash] do work with pod install.
  */
 const fs = require('fs');
 const path = require('path');
-const version = require('../package.json').version;
+const version = process.argv[2];
 
-if (version.includes('-')) {
+if (version.includes('0.0.0')) {
   console.log(`Storing current version for dev version ${version}`);
-
+  const currentPackage = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'));
+  // Backup the current version
   fs.writeFileSync(
     path.join(__dirname, '../meta.json'),
-    JSON.stringify({ version: version.split('-')[0] }, null, '\t')
+    JSON.stringify({ version: currentPackage.version }, null, '\t')
   );
 }


### PR DESCRIPTION
A standard app created with `npx react-native@latest init [appname]` that included this package would crash when reloading on Android due to the error below:

```
No implementation found for void com.reactnativequicksqlite.QuickSQLiteBridge.clearStateNativeJsi() (tried Java_com_reactnativequicksqlite_QuickSQLiteBridge_clearStateNativeJsi and Java_com_reactnativequicksqlite_QuickSQLiteBridge_clearStateNativeJsi__)
```

This PR registers the native method, fixing the missing implementation error and allowing reloading of Android apps. 