### PR TITLE
[fix] Releases action

### DIFF
--- a/.github/workflows/dev-packages.yaml
+++ b/.github/workflows/dev-packages.yaml
@@ -28,7 +28,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build
-        run: yarn build:packages
+        run: yarn build
 
       - name: Development Version
         run: |

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,0 @@
-# Override Yarn command so we can automatically setup the repo on running `yarn`
-
-yarn-path "scripts/bootstrap.js"


### PR DESCRIPTION
This repo contained a `.yarnrc` that would intercept yarn commands to setup the included `example` React native app. This requires a host machine which is setup for CocoaPods development.

This causes the Changesets releases action to fail. We don't actually use the `example` project for anything at this stage. The override has been removed in this PR.  